### PR TITLE
Move `babel-plugin-transform-react-jsx` to `"devDependencies"` Close #10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "author": "Yamagishi Kazutoshi <ykzts@desire.sh>",
   "dependencies": {
-    "babel-plugin-transform-react-jsx": "^6.8.0",
     "classnames": "^2.2.5",
     "context-provider": "^1.0.2",
     "hls.js": "^0.6.6",
@@ -16,6 +15,7 @@
     "babel-loader": "^6.2.7",
     "babel-plugin-transform-class-properties": "^6.18.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-plugin-transform-react-jsx-source": "^6.9.0",
     "css-loader": "^0.25.0",
     "eslint": "^3.8.1",


### PR DESCRIPTION
`yarn add`を実行した時に`--dev`オプションをつけ忘れてしまっていたために[`babel-plugin-transform-react-jsx`](https://www.npmjs.com/package/babel-plugin-transform-react-jsx)が`"devDependencies"`ではなく`"dependencies"` にはいってしまっていた。

`yarn remove`で一度依存から取り除いた上で`--dev`オプションをつけ`yarn add`を再度実行し、package.jsonの内容を変更している。

package.jsonを直接編集しなかったのはyarn.lockに差分が出てしまうのではないかと不安に思ったためだが全くの杞憂であった模様。
### 関連Issue
- #10
