### PR TITLE
Add `URLSearchParams` polyfill Close #4

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "hls.js": "^0.6.6",
     "isomorphic-style-loader": "^1.0.0",
     "react": "^15.3.2",
-    "react-dom": "^15.3.2"
+    "react-dom": "^15.3.2",
+    "url-search-params": "^0.6.1"
   },
   "description": ":tv: Television!",
   "devDependencies": {

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -1,6 +1,7 @@
 import provideContext from 'context-provider/lib/provideContext';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import React, { PropTypes, PureComponent } from 'react';
+import URLSearchParams from 'url-search-params';
 import styles from '../styles/app.css';
 import Video from './video';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3831,6 +3831,10 @@ url-parse@1.0.x:
     querystringify "0.0.x"
     requires-port "1.0.x"
 
+url-search-params:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/url-search-params/-/url-search-params-0.6.1.tgz#3adb7858b807d56b81e7abf3b9dae4978c03f99d"
+
 url@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"


### PR DESCRIPTION
[`URLSearchParams`](https://url.spec.whatwg.org/#urlsearchparams)が実装されていない環境のためのpolyfillとして[`url-search-params`](https://www.npmjs.com/package/url-search-params)を依存ライブラリーに追加する。
### 関連Issue
- #4
