### PR TITLE
Deploy to GitHub Pages Close #16

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,3 +17,9 @@ dependencies:
 test:
   override:
     - yarn test
+
+deployment:
+  publish:
+    branch: master
+    commands:
+      - ./scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -e
+
+REPO=$(git config remote.origin.url)
+
+cd $(dirname $0)/..
+NODE_ENV=production yarn run build
+cd build/public
+sed -i'' -e 's/src="\//src=\".\//' index.html
+rm -rf .git
+git init .
+git config user.name 'CicleCI'
+git config user.email 'sayhi@circleci.com'
+git remote add origin ${REPO}
+git checkout -b gh-pages
+git add index.html *.js
+git commit -am 'add files'
+git push -f origin gh-pages


### PR DESCRIPTION
masterブランチへのpushを起因として[GitHub Pages](https://pages.github.com/)へのデプロイを行うようにする。

単純に済ませられるようにshell scriptで実現している。[CircleCI](https://circleci.com/)上でビルド行ってgh-pagesブランチへとpushする。

またGitHub Pagesではサブディレクトリーが使われるという都合上、HTML文書に記述されている絶対パスを想定しているスクリプトファイルの読み込みに失敗してしまう。そのため`sed`を用いてHTML文書に記述されているスクリプトファイルへのパスを置換させている。

CircleCIにデプロイ用のwrite権限を有する秘密鍵を登録する必要がある。
### 関連Issue
- #16
