### PR TITLE
Copy cirlc.yml to build directory Close #27

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,6 +7,7 @@ REPO=$(git config remote.origin.url)
 cd $(dirname $0)/..
 NODE_ENV=production yarn run build
 cd build/public
+cp ../../circle.yml .
 sed -i'' -e 's/src="\//src=\".\//' index.html
 rm -rf .git
 git init .
@@ -14,6 +15,6 @@ git config user.name 'CicleCI'
 git config user.email 'sayhi@circleci.com'
 git remote add origin ${REPO}
 git checkout -b gh-pages
-git add index.html *.js
+git add index.html *.js circle.yml
 git commit -am 'add files'
 git push -f origin gh-pages


### PR DESCRIPTION
circle.ymlにgh-pagesブランチではCIを行わないように記述している。だがビルドしたものをgh-pagesブランチにpushする際にcircle.ymlはコミットしていないために効力を発揮していなかった。

ビルドスクリプトを実行する際にcircle.ymlをビルドの成果物を入れているディレクトリーにコピーさせるように変更を入れる。
### 関連Issue
- #27
