### PR TITLE
Add build of source map Close #22

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,6 +5,7 @@ set -e
 REPO=$(git config remote.origin.url)
 
 cd $(dirname $0)/..
+rm -rf build
 NODE_ENV=production yarn run build
 cd build/public
 cp ../../circle.yml .
@@ -15,6 +16,6 @@ git config user.name 'CicleCI'
 git config user.email 'sayhi@circleci.com'
 git remote add origin ${REPO}
 git checkout -b gh-pages
-git add index.html *.js circle.yml
+git add index.html *.js *.js.map circle.yml
 git commit -am 'add files'
 git push -f origin gh-pages

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,10 @@ const path = require('path');
 const DefinePlugin = require('webpack/lib/DefinePlugin');
 const pkg = require('./package.json');
 
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+
 module.exports = {
+  devtool: process.env.NODE_ENV === 'development' ? 'cheap-module-eval-source-map' : 'cheap-module-source-map',
   entry: path.join(__dirname, 'src', 'client.jsx'),
   module: {
     loaders: [


### PR DESCRIPTION
Google ChromeやFirefoxなどの開発者ツールでソースコードを元の状態で確認できるように[webpack](https://webpack.github.io/)でのビルド時にソースマップの生成を行うようにする。

開発環境 (`NODE_ENV=development`) では`eval`オプションが有効にしており、リビルド時のビルド速度が速くなるようにしている。
### 関連Issue
- #22
