### PR TITLE
Add support plays inline for iOS Close #23

### DIFF
--- a/src/components/video.jsx
+++ b/src/components/video.jsx
@@ -17,6 +17,9 @@ export default class Video extends PureComponent {
   }
 
   componentDidMount() {
+    if (typeof this.videoElement.playsInline !== 'undefined') {
+      this.videoElement.playsInline = true;
+    }
     const canPlay = this.videoElement.canPlayType('application/vnd.apple.mpegURL');
     if (!['probably', 'maybe'].includes(canPlay) && Hls.isSupported()) {
       this.hls = new Hls();


### PR DESCRIPTION
iOSのSafariでインライン再生できるようにする。

iOSのSafariは再生を開始すると全画面表示される。だがiOS 10のSafariからは`HTMLVideoElement.prototype.playsInline`を`true`にすると`video`要素の動画がインライン再生されるようになった。

`componentDidMount`のタイミングで`HTMLVideoElement.prototype.playsInline`が`undefined`でなければ`true`にするようにしている。

iPhone 6sの実機で確認したところ問題なさそうである。
### 関連Issue
- #23
