### PR TITLE
Add yarn-error.log to .gitignore [ci skip]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /node_modules
 npm-debug.log
+yarn-error.log


### PR DESCRIPTION
Yarnを実行した際にエラーが発生するとyarn-error.logというファイルにログの出力が行われる。エラーが発生した以降にYarnを実行した際にエラーがなければ該当のファイルは消えるが誤ってレポジトリーに混入してしまう可能性がある。

.gitignoreに追加してgitの管理からは無視されるようにする。
