### PR TITLE
Rename `HtmlWebpackPlugin` -> `HtmlPlugin`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const BabiliPlugin = require('babili-webpack-plugin');
-const HtmlWebpackPluign = require('html-webpack-plugin');
+const HtmlPluign = require('html-webpack-plugin');
 const path = require('path');
 const DefinePlugin = require('webpack/lib/DefinePlugin');
 const pkg = require('./package.json');
@@ -31,7 +31,7 @@ module.exports = {
     publicPath: '/',
   },
   plugins: [
-    new HtmlWebpackPluign({
+    new HtmlPluign({
       title: `${pkg.name} (v${pkg.version})`,
     }),
     new DefinePlugin({


### PR DESCRIPTION
[webpack](https://webpack.github.io/)のプラグインの名前は[`html-webpack-plugin`](https://www.npmjs.com/package/html-webpack-plugin)以外はすべて「Webpack」という語を除いた変数名にして読み込んでいる。`html-webpack-plugin`だけ例外的に`HtmlWebpackPlugin`となっており不ぞろいで見目もよろしくない。

この不整合は[`html-webpack-plugin`のREADME](https://github.com/ampedandwired/html-webpack-plugin/blob/v2.24.1/README.md)に書かれているものをそのまま踏襲してしまったために起きている。

動作に影響を及ぼしてしまうような要素ではないが、精神衛生上よろしいものであるとは言えないため修正する。