### PR TITLE
Change devtool option in production build Close #45

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const pkg = require('./package.json');
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
 module.exports = {
-  devtool: process.env.NODE_ENV === 'development' ? 'cheap-module-eval-source-map' : 'cheap-module-source-map',
+  devtool: process.env.NODE_ENV === 'development' ? 'cheap-module-eval-source-map' : 'source-map',
   entry: path.join(__dirname, 'src', 'client.jsx'),
   module: {
     loaders: [


### PR DESCRIPTION
[webpack](https://webpack.github.io/)の設定において`"devtool"`の値を`"cheap-module-source-map"`から`"source-map"`に変更する。

`"cheap-module-source-map"`では一部のモジュールしか表示されず、期待した結果とは違った。値を`"source-map"`にして様子を見たい。

### 関連Issue

- #45