### PR TITLE
Add CNAME Close #52

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,6 +9,7 @@ rm -rf build
 NODE_ENV=production yarn run build
 cd build/public
 cp ../../circle.yml .
+echo baberu.tv > CNAME
 sed -i'' -e 's/src="\//src=\".\//' index.html
 rm -rf .git
 git init .
@@ -16,6 +17,6 @@ git config user.name 'CicleCI'
 git config user.email 'sayhi@circleci.com'
 git remote add origin ${REPO}
 git checkout -b gh-pages
-git add index.html *.js *.js.map circle.yml
+git add index.html *.js *.js.map circle.yml CNAME
 git commit -am 'add files'
 git push -f origin gh-pages


### PR DESCRIPTION
GitHub Pagesの設定からドメイン名の指定ができてレポジトリー内にはドメイン名を固定するようなファイルは不要であると思い、CNAMEファイルはレポジトリーに入れていなかった。しかし設定からドメイン名を指定するとGitHubのほうでCNAMEファイルを特定ブランチにコミットするといった形になっておりブランチを作り直してforce pushするごとにドメイン名の設定が消えてしまっていた。

デプロイスクリプトでCNAMEファイルを作るようにし、とりあえずの解決を図る。

レポジトリー内にドメインが特定されてしまうような記述はできる限りしたくないと考えているため、別の方法がないかどうか模索したい。
