### PR TITLE
Add environment variable for site name Close #46

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
   },
   plugins: [
     new HtmlPluign({
-      title: `${pkg.name} (v${pkg.version})`,
+      title: process.env.BABERU_TV_SITE_NAME || `${pkg.name} (v${pkg.version})`,
     }),
     new DefinePlugin({
       'process.env.NODE_ENV': `'${process.env.NODE_ENV}'`,


### PR DESCRIPTION
サイトの名前を設定するための環境変数「`BABERU_TV_SITE_NAME`」を追加する。

ビルド時に設定しておくことによって`title`要素の値として使われるようになる。

### 関連Issue

- #46