### PR TITLE
Add margin to `video` element

### DIFF
--- a/src/styles/video.css
+++ b/src/styles/video.css
@@ -1,9 +1,12 @@
 .video {
+  background-color: #000;
   margin: 0;
 }
 
 .video video {
+  display: block;
   height: auto;
+  margin: 0 auto;
   max-width: 100%;
   width: 1280px;
 }


### PR DESCRIPTION
`video`要素に`margin`を加えてウィンドウ幅が動画よりも広い場合は中央に表示されるようにする。

また`video`要素が表示される領域の背景を黒にして、より「らしく」見えるようにする。