### PR TITLE
Add minifier for HTML document Close #47

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,14 @@ module.exports = {
   },
   plugins: [
     new HtmlPluign({
+      minify: {
+        collapseBooleanAttributes: true,
+        collapseWhitespace: true,
+        removeAttributeQuotes: true,
+        removeOptionalTags: true,
+        removeScriptTypeAttributes: true,
+        removeStyleLinkTypeAttributes: true,
+      },
       title: process.env.BABERU_TV_SITE_NAME || `${pkg.name} (v${pkg.version})`,
     }),
     new DefinePlugin({


### PR DESCRIPTION
スクリプトファイルと同様にHTML文書もminifyを行うようにする。

HTML文書は仕様にて要素や属性の省略が認められている。必須ではない要素や属性を省略することによってコンテンツ容量の削減に努める。

スクリプトファイルのminifyは開発環境 (`NODE_ENV=development`) 以外で行っているが、HTML文書に対しては全ての環境でminifyを実施するようにしている。これはHTML文書をテキストエディターなどで書いたりはしておらず、[`html-webpack-plugin`](https://www.npmjs.com/package/html-webpack-plugin)によって機械的に作られたものしか存在しないためである。内容に対しての信頼性はある程度担保されているものと判断している。

将来的には`html-webpack-plugin`を使わずにHTML文書の生成を行うことも検討する必要があるかもしれない。だが現時点ではなにも考えていないため、これで充分である。

### 関連Issue

- #47