### PR TITLE
Remove unused command

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,7 +10,6 @@ NODE_ENV=production yarn run build
 cd build/public
 cp ../../circle.yml .
 echo baberu.tv > CNAME
-sed -i'' -e 's/src="\//src=\".\//' index.html
 rm -rf .git
 git init .
 git config user.name 'CicleCI'


### PR DESCRIPTION
機械的に生成されたHTML文書に含まれる`script`要素からスクリプトファイルを読み込むためのパスを絶対パスから相対パスに`sed`を用いて置換させていたが配信されるURIを変更したために不要な処理となっていた。

スクリプトファイルへのパスは相対パスでも絶対パスでも関係なく動作する。だがあってもなくても関係ない処理が存在するのは無駄であるため、削除したい。