### PR TITLE
Do not close window when playing video Close #60

### DIFF
--- a/src/components/video.jsx
+++ b/src/components/video.jsx
@@ -14,9 +14,11 @@ export default class Video extends PureComponent {
   constructor(...args) {
     super(...args);
     this.hls = null;
+    this.handleBeforeUnload = this.handleBeforeUnload.bind(this);
   }
 
   componentDidMount() {
+    window.addEventListener('beforeunload', this.handleBeforeUnload);
     if (typeof this.videoElement.playsInline !== 'undefined') {
       this.videoElement.playsInline = true;
     }
@@ -40,6 +42,17 @@ export default class Video extends PureComponent {
     if (this.hls) {
       this.hls.destroy();
     }
+    window.removeEventListener('beforeunload', this.handleBeforeUnload);
+  }
+
+  handleBeforeUnload(event) {
+    if (!this.videoElement.paused) {
+      const returnValue = '';
+      event.preventDefault();
+      Object.assign(event, { returnValue });
+      return returnValue;
+    }
+    return undefined;
   }
 
   loadSource(uri) {


### PR DESCRIPTION
動画の再生中にウィンドウやタブを閉じられないようにする。

`beforeunload`イベントを使い、`unload`イベントが発火する前に処理を差し込んでいる。`event.preventDefault`メソッドを実行し、処理の差し止めを行う。

仕様の通りであれば`event.preventDefault`メソッドを実行させるのみで充分なはずだが念のため古くからの仕様にもそわせて`event.returnValue`プロパティーに`string`の値を入れたり`return`で`string`の値を返させるといったこともしている。

スクリプトの提供者が閲覧者に対して任意の文字列を表示させるといったことは大半のウェブブラウザーで不可能になっているため、`string`は少しでも容量の削減につなげられるよう空の値にしている。

### 関連Issue

- #60