### PR TITLE
Add form for video URI input Close #2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "context-provider": "^1.0.2",
+    "dialog-polyfill": "^0.4.4",
     "hls.js": "^0.6.6",
     "isomorphic-style-loader": "^1.0.0",
     "react": "^15.3.2",

--- a/src/components/modal.jsx
+++ b/src/components/modal.jsx
@@ -1,0 +1,138 @@
+import dialogPolyfill from 'dialog-polyfill';
+import withStyles from 'isomorphic-style-loader/lib/withStyles';
+import React, { Component, PropTypes } from 'react';
+import styles from '../styles/modal.css';
+
+function handleCancel(event) {
+  event.preventDefault();
+  return false;
+}
+
+@withStyles(styles)
+export default class Modal extends Component {
+  static displayName = 'Modal';
+
+  static contextTypes = {
+    setVideo: PropTypes.func.isRequired,
+  };
+
+  static defaultProps = {
+    open: false,
+  };
+
+  static propTypes = {
+    open: PropTypes.bool.isRequired,
+  };
+
+  constructor(props, ...args) {
+    super(props, ...args);
+    Object.assign(this.state, {
+      open: props.open,
+    });
+    this.handleClose = this.handleClose.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleUriChange = this.handleUriChange.bind(this);
+  }
+
+  state = {
+    open: false,
+    uri: '',
+  };
+
+  componentDidMount() {
+    dialogPolyfill.registerDialog(this.dialogElement);
+    this.dialogElement.addEventListener('cancel', handleCancel);
+    this.dialogElement.addEventListener('close', this.handleClose);
+    const { open } = this.dialogElement;
+    if (this.state.open && !open) {
+      this.showModal();
+    } else if (open && !this.state.open) {
+      this.close();
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props !== nextProps) {
+      this.setState({
+        open: nextProps.open,
+      });
+    }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return (
+      this.state.uri !== nextState.uri ||
+      this.state.open !== nextState.open
+    );
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    const { open } = this.dialogElement;
+    if (nextState.open && !open) {
+      this.showModal();
+    } else if (open && !nextState.open) {
+      this.close();
+    }
+  }
+
+  handleClose() {
+    this.setState({
+      open: false,
+    });
+  }
+
+  handleUriChange({ target }) {
+    const { value } = target;
+    this.setState({
+      uri: value,
+    });
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+    this.context.setVideo({
+      uri: this.state.uri,
+    });
+    return false;
+  }
+
+  close() {
+    this.dialogElement.close();
+  }
+
+  showModal() {
+    this.dialogElement.showModal();
+  }
+
+  render() {
+    return (
+      <dialog
+        className="modal"
+        /* onCancel={handleCancel} */
+        /* onClose={this.handleClose} */
+        ref={component => (this.dialogElement = component)}
+      >
+        <form action="/" method="get" onSubmit={this.handleSubmit}>
+          <fieldset>
+            <legend>
+              <label htmlFor="video-uri">
+                Video <abbr title="Uniform Resource Identifier">URI</abbr>
+              </label>
+            </legend>
+            <input
+              id="video-uri"
+              name="uri"
+              onChange={this.handleUriChange}
+              placeholder="https://example.com/index.m3u8"
+              type="url"
+              value={this.state.uri}
+            />
+          </fieldset>
+          <menu>
+            <button type="submit">Play</button>
+          </menu>
+        </form>
+      </dialog>
+    );
+  }
+}

--- a/src/components/player.jsx
+++ b/src/components/player.jsx
@@ -1,0 +1,25 @@
+import withStyles from 'isomorphic-style-loader/lib/withStyles';
+import React, { Component, PropTypes } from 'react';
+import styles from '../styles/player.css';
+import Video from './video';
+
+@withStyles(styles)
+export default class Player extends Component {
+  static displayName = 'Player';
+
+  static propTypes = {
+    src: PropTypes.string,
+  };
+
+  shouldComponentUpdate(nextProps) {
+    return this.props.src !== nextProps.src;
+  }
+
+  render() {
+    return (
+      <div aria-hidden={!this.props.src} className="player">
+        <Video src={this.props.src} />
+      </div>
+    );
+  }
+}

--- a/src/components/video.jsx
+++ b/src/components/video.jsx
@@ -25,7 +25,6 @@ export default class Video extends PureComponent {
     const canPlay = this.videoElement.canPlayType('application/vnd.apple.mpegURL');
     if (!['probably', 'maybe'].includes(canPlay) && Hls.isSupported()) {
       this.hls = new Hls();
-      this.hls.attachMedia(this.videoElement);
     }
     if (this.props.src) {
       this.loadSource(this.props.src);
@@ -33,7 +32,7 @@ export default class Video extends PureComponent {
   }
 
   componentWillReceiveProps({ src: videoUri }) {
-    if (videoUri && this.props.src !== videoUri) {
+    if (this.props.src !== videoUri) {
       this.loadSource(videoUri);
     }
   }
@@ -57,15 +56,23 @@ export default class Video extends PureComponent {
 
   loadSource(uri) {
     if (this.hls) {
-      this.hls.loadSource(uri);
+      if (uri) {
+        this.hls.attachMedia(this.videoElement);
+        this.hls.loadSource(uri);
+      } else if (!this.hls.url) {
+        this.hls.destroy();
+      }
     } else {
       this.videoElement.src = uri;
+    }
+    if (!uri) {
+      this.videoElement.pause();
     }
   }
 
   render() {
     return (
-      <div aria-hidden={!this.props.src} className="video">
+      <div className="video">
         <video autoPlay controls ref={component => (this.videoElement = component)} />
       </div>
     );

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -1,0 +1,42 @@
+.modal {
+  border: 1px solid #0c0c0c;
+  border-radius: 1rem;
+  max-width: 80%;
+  padding: 4rem 0 1.5rem;
+  width: 650px;
+}
+
+.modal::backdrop,
+.modal + .backdrop {
+  background-color: rgba(0, 0, 0, .8);
+}
+
+.modal fieldset {
+  border: 0;
+  display: block;
+  margin: 0 1rem;
+  padding: 0;
+}
+
+.modal legend {
+  display: none;
+}
+
+.modal input[type="url"] {
+  box-sizing: border-box;
+  display: block;
+  font-size: 1rem;
+  margin: 0;
+  padding: .25rem;
+  width: 100%;
+}
+
+.modal menu {
+  margin: .5rem 1rem 0;
+  text-align: right;
+}
+
+.modal button[type="submit"] {
+  font-size: 1rem;
+  padding: .25rem 1rem;
+}

--- a/src/styles/player.css
+++ b/src/styles/player.css
@@ -1,0 +1,3 @@
+.player[aria-hidden]:not([aria-hidden="false"]) {
+  display: none;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1212,6 +1212,10 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+dialog-polyfill:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/dialog-polyfill/-/dialog-polyfill-0.4.4.tgz#924b5acbf7a587c50de84c174fd5d0f317efa881"
+
 diffie-hellman@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"


### PR DESCRIPTION
動画のURIを入力するためのフォームを追加する。モーダル表示されるが現状では動画の再生中にモーダルを出すことはできない。

モーダルを実装する手間を省くために`dialog`要素を使っているが、Google Chrome以外のウェブブラウザーでは`dialog`要素はまだ実装されていない。Google Chrome以外のウェブブラウザーでも動作するようにpolyfillとして[`dialog-polyfill`](https://www.npmjs.com/package/dialog-polyfill)を使っている。

また動画のURIが入力された場合はページ自体のURIを変えるようにしている。これは動画を再生するページをブックマーク等できるようにするためである。

### 関連Issue

- #2