### PR TITLE
Deployment in release Close #67

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,6 @@ test:
 
 deployment:
   publish:
-    branch: master
+    tag: /v\d+(\.\d+)*/
     commands:
       - ./scripts/deploy.sh


### PR DESCRIPTION
リリースタグ (`/v\d+(?:\.\d+)*/`) がつけられたときにのみ、`gh-pages`ブランチへのデプロイを行うようにする。

これまでは`master`ブランチへの`push`がなされる度に毎回デプロイを行っている。`master`ブランチへのデプロイが連続して行われてしまうときに不便であるため、その解消を図るためにリリースタグがつけられるまではデプロイをしないようにする。

### 関連Issue

- #67