### PR TITLE
Replace `PureComponent` to `Component` Close #64

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -1,7 +1,7 @@
 import provideContext from 'context-provider/lib/provideContext';
 import dialogStyles from 'dialog-polyfill/dialog-polyfill.css';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
-import React, { PropTypes, PureComponent } from 'react';
+import React, { Component, PropTypes } from 'react';
 import URLSearchParams from 'url-search-params';
 import styles from '../styles/app.css';
 import Modal from './modal';
@@ -18,7 +18,7 @@ function getQueryString() {
   insertCss: PropTypes.func.isRequired,
 })
 @withStyles(dialogStyles, styles)
-export default class App extends PureComponent {
+export default class App extends Component {
   static contextTypes = {
     insertCss: PropTypes.func.isRequired,
   };
@@ -56,6 +56,10 @@ export default class App extends PureComponent {
 
   componentDidMount() {
     window.addEventListener('popstate', this.handlePopState);
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return this.state.videoUri !== nextState.videoUri;
   }
 
   componentWillUpdate(nextProps, nextState) {

--- a/src/components/video.jsx
+++ b/src/components/video.jsx
@@ -1,10 +1,10 @@
 import Hls from 'hls.js';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
-import React, { PropTypes, PureComponent } from 'react';
+import React, { Component, PropTypes } from 'react';
 import styles from '../styles/video.css';
 
 @withStyles(styles)
-export default class Video extends PureComponent {
+export default class Video extends Component {
   static displayName = 'Video';
 
   static propTypes = {
@@ -35,6 +35,10 @@ export default class Video extends PureComponent {
     if (this.props.src !== videoUri) {
       this.loadSource(videoUri);
     }
+  }
+
+  shouldComponentUpdate(nextProps) {
+    return this.props.src !== nextProps.src;
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
`PureComponent`を使って実装していた箇所を`Component`を使うように置き換える。

`PureComponent`は`Component.prototype.shouldComponentUpdate`メソッドで行う`props`と`state`の比較を暗黙的に実施してくれるコンポーネントである。これは`props`や`state`の持つ値が多く、また`render`メソッドの中でも広く使われているのであれば効果が得られるものだが現状はそこまでに至っていないため使う意味は薄い。

`Component.prototype.shouldComponent`メソッドで明示的な比較を行うようにする。

### 関連Issue

- #64