### PR TITLE
Fix backdrop background color Close #73

### DIFF
--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -6,7 +6,10 @@
   width: 650px;
 }
 
-.modal::backdrop,
+.modal::backdrop {
+  background-color: rgba(0, 0, 0, .8);
+}
+
 .modal + .backdrop {
   background-color: rgba(0, 0, 0, .8);
 }


### PR DESCRIPTION
Safariでのみモーダル表示を行っているときに出るbackdropへのスタイルが有効になっていなかった。これは`::backdrop`疑似要素にSafariが対応しておらず、不正なセレクターとして認識されてしまっているためである。

`::backdrop`への指定とpolyfillで使われる`dialog + .backdrop`の指定をそれぞれ分けることによって解決を図る。

### 関連Issue

- #73