### PR TITLE
Change video URI save timing Close #95

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -3,7 +3,6 @@ import dialogStyles from 'dialog-polyfill/dialog-polyfill.css';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import React, { Component, PropTypes } from 'react';
 import URLSearchParams from 'url-search-params';
-import database from '../databases/media';
 import styles from '../styles/app.css';
 import Header from './header';
 import Modal from './modal';
@@ -80,16 +79,8 @@ export default class App extends Component {
   }
 
   setVideo({ uri }) {
-    database.transaction('rw', database.videos, async () => {
-      if (uri && (await database.videos.where('uri').equals(uri).count()) < 1) {
-        await database.videos.add({
-          uri,
-          createdAt: new Date(),
-        });
-      }
-      this.setState({
-        videoUri: uri,
-      });
+    this.setState({
+      videoUri: uri,
     });
   }
 


### PR DESCRIPTION
動画のURIを`IndexedDB`に保存するタイミングを変更する。

動画のURIはフォームから入力がされてすぐに保存をしていたが再生できない動画のURIも`IndexedDB`に記録してしまっている。`video`要素 (`HTMLVideoElement`) の`canplay`イベントが発火したのを確認してから動画のURIを`IndexedDB`に保存させるようにしている。

`canplay`イベントが適切に発火されることはGoogle ChromeとSafari、Firefoxで確認して問題なさそうである。

### 関連Issue

- #95