### PR TITLE
Add error handler for video component Close #38

### DIFF
--- a/__tests__/components/player.jsx
+++ b/__tests__/components/player.jsx
@@ -5,23 +5,25 @@ import Player from '../../src/components/player';
 
 @provideContext({
   insertCss: PropTypes.func.isRequired,
+  setVideo: PropTypes.func.isRequired,
 })
 class MockPlayer extends Player {
 }
 
 function insertCss() {}
+function setVideo() {}
 
 test('mount', () => {
-  const player = mount(<MockPlayer context={{ insertCss }} />);
+  const player = mount(<MockPlayer context={{ insertCss, setVideo }} />);
   expect(player.find('.player').length).toBe(1);
 });
 
 test('aria-hidden=true', () => {
-  const player = mount(<MockPlayer context={{ insertCss }} />);
+  const player = mount(<MockPlayer context={{ insertCss, setVideo }} />);
   expect(player.find('.player[aria-hidden]').length).toBe(1);
 });
 
 test('aria-hidden=false', () => {
-  const player = mount(<MockPlayer context={{ insertCss }} src="https://example.com/index.m3u8" />);
+  const player = mount(<MockPlayer context={{ insertCss, setVideo }} src="https://example.com/index.m3u8" />);
   expect(player.find('.player[aria-hidden=false]').length).toBe(1);
 });

--- a/src/components/video.jsx
+++ b/src/components/video.jsx
@@ -8,6 +8,10 @@ import styles from '../styles/video.css';
 export default class Video extends Component {
   static displayName = 'Video';
 
+  static contextTypes = {
+    setVideo: PropTypes.func.isRequired,
+  };
+
   static propTypes = {
     src: PropTypes.string,
   };
@@ -17,6 +21,7 @@ export default class Video extends Component {
     this.hls = null;
     this.handleBeforeUnload = this.handleBeforeUnload.bind(this);
     this.handleCanPlay = this.handleCanPlay.bind(this);
+    this.handleError = this.handleError.bind(this);
   }
 
   componentDidMount() {
@@ -27,6 +32,7 @@ export default class Video extends Component {
     const canPlay = this.videoElement.canPlayType('application/vnd.apple.mpegURL');
     if (!['probably', 'maybe'].includes(canPlay) && Hls.isSupported()) {
       this.hls = new Hls();
+      this.hls.on(Hls.Events.ERROR, this.handleError);
     }
     if (this.props.src) {
       this.loadSource(this.props.src);
@@ -72,6 +78,16 @@ export default class Video extends Component {
     });
   }
 
+  handleError() {
+    if (this.props.src) {
+      // eslint-disable-next-line no-alert
+      alert('Video playback failed.');
+      this.context.setVideo({
+        uri: '',
+      });
+    }
+  }
+
   loadSource(uri) {
     if (this.hls) {
       if (uri) {
@@ -95,6 +111,7 @@ export default class Video extends Component {
           autoPlay
           controls
           onCanPlay={this.handleCanPlay}
+          onError={this.handleError}
           ref={component => (this.videoElement = component)}
         />
       </div>


### PR DESCRIPTION
`Video`コンポーネントにエラーハンドラーを追加する。

動画を再生しようとしたタイミングでエラーが発生した場合に`alert`を使ってそれらしいメッセージの表示を行う。

見た目を整えるという意味で`alert`はない選択肢ではあるが、ひとまずはこれで済ませる。将来的にはエラーはモーダルを表示させるようにしたい。

### 関連Issue

- #38