### PR TITLE
Refactor `CNAME` generator Close #105

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,7 +9,12 @@ rm -rf build
 NODE_ENV=production yarn run build
 cd build/public
 cp ../../circle.yml .
-echo baberu.tv > CNAME
+cat <<__EOS | node | tee CNAME
+const { parse: parseURL } = require('url');
+const { homepage: uri } = require('../../package.json');
+const { host } = parseURL(uri);
+console.log(host);
+__EOS
 rm -rf .git
 git init .
 git config user.name 'CicleCI'


### PR DESCRIPTION
`CNAME`ファイルを生成するときに`package.json`の内容を使うようにする。似たような記述が重複管理されてしまうのを避けるためである。

### 関連Issue

- #105