### PR TITLE
Move `Modal` component out of main element Close #108

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -95,8 +95,8 @@ export default class App extends Component {
         <Header videoUri={this.state.videoUri} />
         <main>
           <Player src={this.state.videoUri} />
-          <Modal open={!this.state.videoUri} />
         </main>
+        <Modal open={!this.state.videoUri} />
       </div>
     );
   }


### PR DESCRIPTION
`Modal`コンポーネントを`main`要素の外に出す。

`Modal`コンポーネントはメインのコンテンツではないものが表示されることが自明なコンポーネントである。そのため、`main`要素の中にあるのは不適切。

### 関連Issue

- #108