### PR TITLE
Remove `classnames` from dependencies Close #111

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "url": "https://github.com/baberutv/baberutv/issues"
   },
   "dependencies": {
-    "classnames": "^2.2.5",
     "context-provider": "^1.0.2",
     "dexie": "^v2.0.0-beta.4",
     "dialog-polyfill": "^0.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,10 +954,6 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
-
 clean-css@3.4.x:
   version "3.4.20"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-3.4.20.tgz#c0d8963b5448e030f0bcd3ddd0dac4dfe3dea501"


### PR DESCRIPTION
[`classnames`](https://www.npmjs.com/package/classnames)は使われていないが[`package.json`の`"dependecies"`](https://github.com/baberutv/baberutv/blob/v0.4.1/package.json#L6)に書かれている。インストールの時間が長くなってしまうだけでメリットはないので削除する。

### 関連Issue

- #111