### PR TITLE
`yarn install` -> `yarn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Install
 
 ```shell
-$ yarn install
+$ yarn
 $ yarn start
 ```
 

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ dependencies:
     - ~/.yarn-cache
   override:
     - npm install -g yarn
-    - yarn install
+    - yarn
 
 test:
   override:


### PR DESCRIPTION
[Yarn](https://yarnpkg.com/)のCLIコマンドは引数を無指定にして実行すると`install`が指定されたものとして動作する。これまでは`yarn install`と明示的に引数を指定していたが、無駄なので省く。