### PR TITLE
Add `yarn build` in CircleCI dependencies Close #117

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,7 @@ dependencies:
   override:
     - npm install -g yarn
     - yarn
+    - NODE_ENV=test yarn build
 
 test:
   override:


### PR DESCRIPTION
きちんとビルドができるかをCircleCIで確認しておきたいため、CircleCIで依存ライブラリーをインストールした後に`yarn build`を実行するようにする。

万が一にも壊れた状態のものが`master`ブランチに混入しないようにしておきたい。

### 関連Issue

- #117