### PR TITLE
Remove `run` from argv of Yarn Close #119

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,7 +6,7 @@ REPO=$(git config remote.origin.url)
 
 cd $(dirname $0)/..
 rm -rf build
-NODE_ENV=production yarn run build
+NODE_ENV=production yarn build
 cd build/public
 cp ../../circle.yml .
 cat <<__EOS | node | tee CNAME


### PR DESCRIPTION
YarnのCLIコマンドである`yarn`はビルトインコマンドと競合しない場合には引数から`run`を省略できるので冗長にならないよう省略する。

### 関連Issue

- #119