### PR TITLE
Replace `DefinePlugin` to `EnvironmentPlugin` Close #123

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const BabiliPlugin = require('babili-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 const HtmlPluign = require('html-webpack-plugin');
 const path = require('path');
-const DefinePlugin = require('webpack/lib/DefinePlugin');
+const EnvironmentPlugin = require('webpack/lib/EnvironmentPlugin');
 const OccurrenceOrderPlugin = require('webpack/lib/optimize/OccurrenceOrderPlugin');
 const pkg = require('./package.json');
 
@@ -49,9 +49,9 @@ module.exports = {
       template: path.join(__dirname, 'src', 'templates', 'index.hbs'),
       title: process.env.BABERU_TV_SITE_NAME || `${pkg.name} (v${pkg.version})`,
     }),
-    new DefinePlugin({
-      'process.env.NODE_ENV': `'${process.env.NODE_ENV}'`,
-    }),
+    new EnvironmentPlugin([
+      'NODE_ENV',
+    ]),
     new CopyPlugin([
       {
         from: path.join(__dirname, 'src', 'assets', 'favicon.ico'),


### PR DESCRIPTION
`DefinePlugin`を`EnvironmentPlugin`に置き換える。

基本的に環境変数に紐付ける以外の方法は取らないつもりでいるため、`EnvironmentPlugin`ではなく`DefinePlugin`でなければならない場面は存在しえないと考えている。もし`DefinePlugin`が必要な場面が出てきた場合は、そのときに改めて`DefinePlugin`を使うようにする。ただしそうした場合であっても`EnvironmentPlugin`との併用で良さそうである。

### 関連Issue

- #123