### PR TITLE
Add `.nojekyll` Close #127

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -15,6 +15,7 @@ const { homepage: uri } = require('../../package.json');
 const { host } = parseURL(uri);
 console.log(host);
 __EOS
+touch .nojekyll
 rm -rf .git
 git init .
 git config user.name 'CicleCI'
@@ -22,6 +23,7 @@ git config user.email 'sayhi@circleci.com'
 git remote add origin ${REPO}
 git checkout -b gh-pages
 git add \
+  .nojekyll \
   CNAME \
   circle.yml \
   favicon.ico \


### PR DESCRIPTION
`gh-pages`ブランチにデプロイを行う際に、`.nojekyll`という名前のファイルを生成して配置させるようにする。これによってGitHub PagesでJekyllとは認識されずに静的ファイルの配信が行われるだけとなる。

Jekyllによるビルドの時間が省略されることによって、迅速な反映ができるようになるのではないかと期待する。

### 関連Issue

- #127