### PR TITLE
Fix regexp for `.hbs` Close #129

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ module.exports = {
       },
       {
         loader: 'handlebars-loader',
-        test: /\.hbs/,
+        test: /\.hbs$/,
       },
     ],
   },


### PR DESCRIPTION
Handlebars.jsのための正規表現に誤りがあったため修正する。

拡張子が`.hbs`であるときにのみ処理をさせたかったが、末尾に`$`を入れ忘れてしまっていたために、途中に`.hbs`が含まれるものがすべてマッチしてしまっていた。現状で動作に不具合は生じていないが、明確な誤りであるため修正する。

### 関連Issue

- #129