### PR TITLE
Add coverage Close #102

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 /build
+/coverage
 /node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build
+/coverage
 /node_modules
 npm-debug.log
 yarn-error.log

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
   },
   "homepage": "https://baberu.tv/",
   "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx}"
+    ],
     "moduleNameMapper": {
       "^.+\\.css$": "<rootDir>/__tests__/__mocks__/styleMock.js"
     },
@@ -68,7 +71,7 @@
     "lint": "eslint --ext js --ext jsx . && flow check",
     "start": "webpack-dev-server",
     "test": "${npm_execpath:-npm} run lint && ${npm_execpath:-npm} run test-only",
-    "test-only": "jest"
+    "test-only": "jest --coverage"
   },
   "version": "0.4.4"
 }


### PR DESCRIPTION
[Jest](https://facebook.github.com/jest/)にオプションを追加してカバレッジの計測を行えるようにする。

計測したカバレッジは現状コンソール出力するだけであり、継続的なカバー率の記録は行わせない。[Coveralls](https://coveralls.io/)などのサービスに記録を残し、進行具合が明確に見えるようにするべきではあるが、今は考えない。

### 関連Issue

- #102