### PR TITLE
Add `404` page Close #48

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -25,6 +25,7 @@ git checkout -b gh-pages
 git add \
   .nojekyll \
   CNAME \
+  404.html \
   circle.yml \
   favicon.ico \
   index.html \

--- a/src/assets/404.html
+++ b/src/assets/404.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<meta charset=UTF-8>
+<style>
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  background-color: #333;
+  font-family: sans-serif;
+}
+
+header {
+  left: 0;
+  margin: 0;
+  padding: 0 0 2rem;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 101;
+}
+
+header h1 {
+  background-color: rgba(255, 255, 255, .8);
+  color: #666;
+  font-size: 1.5rem;
+  line-height: 1;
+  margin: 0;
+  padding: .5em 1em;
+  text-align: center;
+}
+
+header h1 a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+main {
+  margin-top: 3rem;
+}
+
+.http-status {
+  margin: 0;
+  padding: 0;
+}
+
+.status-code,
+.reason-phrase {
+  color: #ccc;
+  margin: 0;
+  line-height: 1;
+  text-align: center;
+  padding: 0
+}
+
+.status-code {
+  font-size: 20rem;
+}
+
+.reason-phrase {
+  font-size: 1.5rem;
+}
+</style>
+<title>404 Not Found</title>
+<header>
+  <h1>
+    <a href=/ title="back to top page">TV</a>
+  </h1>
+</header>
+<main>
+  <section class=http-status>
+    <h2 class=status-code>404</h2>
+    <p class=reason-phrase>Not Found</p>
+  </section>
+</main>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,6 +57,10 @@ module.exports = {
         from: path.join(__dirname, 'src', 'assets', 'favicon.ico'),
         to: path.join(__dirname, 'build', 'public', 'favicon.ico'),
       },
+      {
+        from: path.join(__dirname, 'src', 'assets', '404.html'),
+        to: path.join(__dirname, 'build', 'public', '404.html'),
+      },
     ]),
     ...(process.env.NODE_ENV !== 'development' ? [
       new OccurrenceOrderPlugin(),


### PR DESCRIPTION
`gh-pages`ブランチに`404.html`を配置させるようにする。

[GitHub Pages](https://pages.github.com/)ではHTTPステータス 404 Not foundが発生したときに`/404.html`を開こうとする。ユーザーが誤ったURIでページを開こうとしたときにページが存在しないことを伝えられるようにと目論む。

### 関連Issue

- #48