### PR TITLE
Change Yarn cache directory Close #140

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
 
 dependencies:
   cache_directories:
-    - ~/.yarn-cache
+    - ~/.cache/yarn
   override:
     - npm install -g yarn
     - yarn


### PR DESCRIPTION
Yarnのキャッシュディレクトリーがv0.17.0で変更になった。それに追従させるかたちでCircleCIでのキャッシュディレクトリーの設定も変更する。

### 関連Issue

- #140