### PR TITLE
Add `webpack-dev-server` settings Close #143

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,10 @@ const pkg = require('./package.json');
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
 module.exports = {
+  devServer: {
+    host: '0.0.0.0',
+    port: +(process.env.PORT || 8080),
+  },
   devtool: process.env.NODE_ENV === 'development' ? 'cheap-module-eval-source-map' : 'source-map',
   entry: path.join(__dirname, 'src', 'client.jsx'),
   module: {


### PR DESCRIPTION
[`webpack-dev-server`の設定]を変更する。

- 開発サーバーのホストを`0.0.0.0`にして`localhost`以外からも開けるように
- 開発サーバーの起動時に付与されている環境変数に応じてポートを任意に変更できるように

の二点が実現される。

### 関連Issue

- #143

[`webpack-dev-server`の設定]: https://webpack.github.io/docs/webpack-dev-server.html