### PR TITLE
Stop using `cheap-module-eval-source-map`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     host: '0.0.0.0',
     port: +(process.env.PORT || 8080),
   },
-  devtool: process.env.NODE_ENV === 'development' ? 'cheap-module-eval-source-map' : 'source-map',
+  devtool: 'source-map',
   entry: path.join(__dirname, 'src', 'client.jsx'),
   module: {
     loaders: [


### PR DESCRIPTION
[webpack]のビルドで`cheap-module-eval-source-map`を使うのを止める。

これまでwebpackのビルド時においてソースマップファイルを作成するために開発環境 (`NODE_ENV=development`) では`source-map`ではなく`cheap-module-eval-source-map`を使っていたが、行がずれたりしてあまり都合が良くない。`source-map`ではビルドの時間が`cheap-module-eval-source-map`よりも延びてしまうので根本的な対処は必要であるので要調査である。

[webpack]: https://webpack.github.io/