### PR TITLE
Add `engineStrict: true` Close #161

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "node": ">= 5.0.0",
     "yarn": ">= 0.17.0"
   },
+  "engineStrict": true,
   "homepage": "https://baberu.tv/",
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
`package.json`に`engineStrict: true`を追加する。

`engineStrict: true`が`package.json`に書かれている場合、`engine`の指定とnpmのインストール時の実行環境に差異があるときにエラーが返されインストールすることができなくなる。

Node.js v5.x以降以外の環境からは処理することができないので、ある程度の縛りを設けるようにしておきたい。

### 関連Issue

- #161