### PR TITLE
Change webpack config for loaders Close #171

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,22 +16,22 @@ module.exports = {
   devtool: 'source-map',
   entry: path.join(__dirname, 'src', 'client.jsx'),
   module: {
-    loaders: [
+    rules: [
       {
         exclude: /node_modules/,
-        loader: 'babel-loader',
         test: /\.jsx?$/,
+        use: 'babel-loader',
       },
       {
-        loaders: [
+        test: /\.css$/,
+        use: [
           'isomorphic-style-loader',
           'css-loader',
         ],
-        test: /\.css$/,
       },
       {
-        loader: 'handlebars-loader',
         test: /\.hbs$/,
+        use: 'handlebars-loader',
       },
     ],
   },


### PR DESCRIPTION
webpack v2から`module.loaders`ではなく`module.rules`でローダーの設定をするようになるそのためwebpackの設定ファイルを新しい書きかたに追従させる。

### 関連Issue

- #171