### PR TITLE
Using `--env` argument for webpack Closing #174

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "jest": "^18.0.0",
     "react-addons-test-utils": "^15.3.2",
     "webpack": "^2.2.0-rc.0",
-    "webpack-dev-server": "^2.2.0-rc.0"
+    "webpack-dev-server": "^2.2.0-rc.0",
+    "webpack-merge": "^1.1.2"
   },
   "engines": {
     "node": ">= 5.0.0",
@@ -79,7 +80,7 @@
     "url": "https://github.com/baberutv/baberutv.git"
   },
   "scripts": {
-    "build": "webpack",
+    "build": "webpack --env ${NODE_ENV:-development}",
     "lint": "eslint --ext js --ext jsx . && flow check",
     "start": "webpack-dev-server",
     "test": "${npm_execpath:-npm} run lint && ${npm_execpath:-npm} run test-only",

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -13,4 +13,6 @@ function insertCss(...styles: Array<Object>): () => void {
   };
 }
 
+console.log(process.env.NODE_ENV);
+
 ReactDOM.render(<App context={{ insertCss }} />, document.getElementById('root'));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,11 +4,12 @@ const HtmlPluign = require('html-webpack-plugin');
 const path = require('path');
 const EnvironmentPlugin = require('webpack/lib/EnvironmentPlugin');
 const OccurrenceOrderPlugin = require('webpack/lib/optimize/OccurrenceOrderPlugin');
+const merge = require('webpack-merge');
 const pkg = require('./package.json');
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
-module.exports = {
+const clientConfig = {
   devServer: {
     host: '0.0.0.0',
     port: +(process.env.PORT || 8080),
@@ -36,7 +37,7 @@ module.exports = {
     ],
   },
   output: {
-    filename: process.env.NODE_ENV === 'development' ? '[name].js?[chunkhash]' : '[name].[chunkhash].js',
+    filename: '[name].js?[chunkhash]',
     path: path.join(__dirname, 'build', 'public'),
     publicPath: '/',
   },
@@ -66,10 +67,6 @@ module.exports = {
         to: path.join(__dirname, 'build', 'public', '404.html'),
       },
     ]),
-    ...(process.env.NODE_ENV !== 'development' ? [
-      new OccurrenceOrderPlugin(),
-      new BabiliPlugin(),
-    ] : []),
   ],
   resolve: {
     extensions: [
@@ -77,4 +74,21 @@ module.exports = {
       '.jsx',
     ],
   },
+};
+
+module.exports = (env = process.env.NODE_ENV) => {
+  switch (env) {
+    case 'production':
+      return merge(clientConfig, {
+        output: {
+          filename: '[name].[chunkhash].js',
+        },
+        plugins: [
+          new OccurrenceOrderPlugin(),
+          new BabiliPlugin(),
+        ],
+      });
+    default:
+      return clientConfig;
+  }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3476,6 +3476,10 @@ lodash.clonedeep@^3.0.0:
     lodash._baseclone "^3.0.0"
     lodash._bindcallback "^3.0.0"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -3483,6 +3487,10 @@ lodash.cond@^4.3.0:
 lodash.defaults@^4.0.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+
+lodash.differencewith@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz#bafafbc918b55154e179176a00bb0aefaac854b7"
 
 lodash.filter@^4.4.0:
   version "4.6.0"
@@ -3508,6 +3516,18 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isequal@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.4.0.tgz#6295768e98e14dc15ce8d362ef6340db82852031"
+
+lodash.isfunction@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz#4db709fc81bc4a8fd7127a458a5346c5cdce2c6b"
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
@@ -3523,6 +3543,10 @@ lodash.map@^4.4.0:
 lodash.merge@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+
+lodash.mergewith@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
 
 lodash.pick@^4.2.1:
   version "4.4.0"
@@ -3543,6 +3567,10 @@ lodash.reject@^4.4.0:
 lodash.some@^4.4.0, lodash.some@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
+
+lodash.unionwith@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.unionwith/-/lodash.unionwith-4.6.0.tgz#74d140b5ca8146e6c643c3724f5152538d9ac1f0"
 
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.16.4, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.2"
@@ -5404,6 +5432,18 @@ webpack-dev-server@^2.2.0-rc.0:
     supports-color "^3.1.1"
     webpack-dev-middleware "^1.9.0"
     yargs "^6.0.0"
+
+webpack-merge@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-1.1.2.tgz#49f2a68ba5fd34bb13c338c184c7028d93843432"
+  dependencies:
+    lodash.clonedeep "^4.5.0"
+    lodash.differencewith "^4.5.0"
+    lodash.isequal "^4.4.0"
+    lodash.isfunction "^3.0.8"
+    lodash.isplainobject "^4.0.6"
+    lodash.mergewith "^4.6.0"
+    lodash.unionwith "^4.6.0"
 
 webpack-sources@^0.1.0, webpack-sources@^0.1.2:
   version "0.1.3"


### PR DESCRIPTION
webpackをCLIから実行する際に`--env`オプションを使うようにする。

webpackの設定ファイル (`webpack.config.js`) は`function`を返すとその`function`の第一引数に`--env`オプションで指定した値が入れられる。`object`や配列の形でwebpackの設定をそのまま返すよりは読みやすさも確保できるのではないかと期待する。

### 関連Issue

- #174