### PR TITLE
Remove error handling #177

### DIFF
--- a/src/components/video.jsx
+++ b/src/components/video.jsx
@@ -25,7 +25,6 @@ export default class Video extends Component {
     this.hls = null;
     this.handleBeforeUnload = this.handleBeforeUnload.bind(this);
     this.handleCanPlay = this.handleCanPlay.bind(this);
-    this.handleError = this.handleError.bind(this);
   }
 
   componentDidMount() {
@@ -36,7 +35,6 @@ export default class Video extends Component {
     const canPlay = this.videoElement.canPlayType('application/vnd.apple.mpegURL');
     if (!['probably', 'maybe'].includes(canPlay) && Hls.isSupported()) {
       this.hls = new Hls();
-      this.hls.on(Hls.Events.ERROR, this.handleError);
     }
     if (this.props.src) {
       this.loadSource(this.props.src);
@@ -82,16 +80,6 @@ export default class Video extends Component {
     });
   }
 
-  handleError() {
-    if (this.props.src) {
-      // eslint-disable-next-line no-alert
-      alert('Video playback failed.');
-      this.context.setVideo({
-        uri: '',
-      });
-    }
-  }
-
   loadSource(uri) {
     if (this.hls) {
       if (uri) {
@@ -115,7 +103,6 @@ export default class Video extends Component {
           autoPlay
           controls
           onCanPlay={this.handleCanPlay}
-          onError={this.handleError}
           ref={component => (this.videoElement = component)}
         />
       </div>


### PR DESCRIPTION
よくわからないタイミングで発火してしまい動画再生の阻害になる動画再生時のエラーハンドリングの処理を一時的に取り除く。

もう少し検証をした上で追加する。

### 関連Issue

- #177