### PR TITLE
Remove override rules for ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,10 +4,5 @@
   },
   "extends": "airbnb",
   "parser": "babel-eslint",
-  "root": true,
-  "rules": {
-    "import/no-extraneous-dependencies": ["error", {
-      "devDependencies": ["**/webpack.config.js"]
-    }]
-  }
+  "root": true
 }


### PR DESCRIPTION
ESLintの設定はAirbnbのものを使っているが、一部のルールを上書きしている。これはwebpackの設定ファイルから開発用の依存パッケージを使用した際に警告が出てしまうためであった。

しかし https://github.com/airbnb/javascript/commit/ec08ca84ba756543df99bee9c268866512634622 でwebpackの設定ファイルが例外として扱われるようになっている。そのためこちらの側でルールの上書きをする必要はなくなった。

なので煩雑さをなくすために、自前で上書きしているルールは削除する。