### PR TITLE
Remove override ESLint rule for tests

### DIFF
--- a/__tests__/.eslintrc.json
+++ b/__tests__/.eslintrc.json
@@ -3,8 +3,5 @@
     "jest": true
   },
   "extends": "../.eslintrc.json",
-  "root": true,
-  "rules": {
-    "import/no-extraneous-dependencies": "off"
-  }
+  "root": true
 }


### PR DESCRIPTION
aaaff33bfb5bae570e797ec9127e446f85f9fedf で不要なESLintのルールの上書きを削除したが、テスト用のファイルを対象とするものが抜けてしまっていた。テスト用のものでも同様の処置を行う。