### PR TITLE
Add `Dockerfile` Close #196

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:6.10.0
+
+ENV PATH /root/.yarn/bin:${PATH}
+ENV YARN_VERSION 0.20.3
+
+RUN \
+  curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VERSION}
+
+WORKDIR /app
+
+COPY ./package.json ./yarn.lock /app/
+RUN yarn
+
+COPY . /app/
+
+EXPOSE 8080
+CMD ["yarn", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.0"
+services:
+  webpack:
+    build:
+      context: .
+      dockerfile: ./dockerfile
+    ports:
+      - "8080:8080"
+    volumes:
+      - node_modules:/app/node_modules
+      - ./__tests__:/app/__tests__
+      - ./scripts:/app/scripts
+      - ./src:/app/src
+      - ./.babelrc:/app/.babelrc
+      - ./.eslintignore:/app/.eslintignore
+      - ./.eslintrc.json:/app/.eslintrc.json
+      - ./package.json:/app/package.json
+      - ./webpack.config.json:/app/webpack.config.json
+      - ./yarn.lock:/app/yarn.lock
+volumes:
+  node_modules:


### PR DESCRIPTION
Dockerを用いた開発環境の構築を行えるようにする。これにより環境構築の余計な手間が省けるようになることを期待する。

また現在は静的なファイルを配信するだけで良く、GitHub Pagesにデプロイしているが、これを将来的にサーバーサイドレンダリングなどの動的な要素を加えるとき、Dockerを使っていればデプロイに余計な手間や苦労をかけずに済むことが期待できる。

### 関連Issue

- #196