### PR TITLE
Fix deploy from CircleCI Close #223

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,6 @@ jobs:
           command: cat ./coverage/lcov.info | $(yarn bin)/coveralls || echo "1"
       - deploy:
           command: |
-            if echo ${CIRCLE_TAG} | grep -Eq "^v\\d(\\.\\d+)*$"; then
+            if echo $(git describe) | grep -Eq "^v\\d(\\.\\d+)*$"; then
               ./scripts/deploy.sh
             fi


### PR DESCRIPTION
d2f23717cfc30ebfd103f6442e43ee6189baa701 にてCircleCI 2.0を移行したが、CircleCI 2.0では環境変数`$CIRCLE_TAG`が存在しないため、リリースタグを切った際に行われるデプロイが正常に行えなくなってしまった。

`git describe`コマンドの返す値を評価して、タグが切られているコミットである場合にデプロイを行わせるようにする。

### 関連Issue

- #223