### PR TITLE
Fix `grep` regexp Close #223

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,6 @@ jobs:
           command: cat ./coverage/lcov.info | $(yarn bin)/coveralls || echo "1"
       - deploy:
           command: |
-            if echo $(git describe) | grep -Eq "^v\\d(\\.\\d+)*$"; then
+            if echo $(git describe) | grep -Eq "^v[[:digit:]](\\.[[:digit:]]+)*$"; then
               ./scripts/deploy.sh
             fi


### PR DESCRIPTION
CircleCI上でデプロイ時に実行されるコマンドに含まれる`grep`コマンドの引数がmacOSでしか意図した通りに動かず、GNU/Linuxでは適切に認識されないため、正常にデプロイが行われていない。

macOSの`grep`では引数に`-E`が与えられていれば数値のマッチに`\d`が使えるが、GNU/Linuxでは`-P`引数 (Perl互換モード) を与えなければならない。相互運用をさせるためには`[[:digit:]]`を使えば良いので、こちらを使うようにする。

### 関連Issue

- #223