### PR TITLE
Fix broken command of deploy script Close #226

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,12 +8,12 @@ cd $(dirname $0)/..
 rm -rf build
 yarn build -- --env production
 cd build/public
-cat <<EOF tee circle.yml
+cat <<__EOF | tee circle.yml
 general:
   branches:
     ignore:
       - gh-pages
-EOF
+__EOF
 cat <<__EOS | node | tee CNAME
 const { parse: parseURL } = require('url');
 const { homepage: uri } = require('../../package.json');


### PR DESCRIPTION
d2f23717cfc30ebfd103f6442e43ee6189baa701 にて`gh-pages`ブランチでCircleCIの処理が実行されないようにする`circle.yml`を書き出す処理を追加したが追加したコマンドでパイプ (`|`) を書き漏らしてしまっていて、処理が正常に走らなくなってしまっていた。パイプを書き足し、問題なく動作するよう修正する。

### 関連Issue

- #226