### PR TITLE
Add `add_ssh_keys` step to `.circleci/config.yml` Close #228

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
       - run:
           name: Post-Test
           command: cat ./coverage/lcov.info | $(yarn bin)/coveralls || echo "1"
+      - add_ssh_keys
       - deploy:
           command: |
             if echo $(git describe) | grep -Eq "^v[[:digit:]](\\.[[:digit:]]+)*$"; then


### PR DESCRIPTION
デプロイ用の鍵を追加させるタスクをCircleCI用の設定ファイルに追加する。

### 関連Issue

- #228 