### PR TITLE
Fix Dockerfile name for case sensitive filesystem

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   webpack:
     build:
       context: .
-      dockerfile: ./dockerfile
+      dockerfile: ./Dockerfile
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
`docker-compose.yml`において`Dockerfile`の名前が`dockerfile`になってしまっていたのを修正する。

これはmacOSなどのファイル名の大文字と小文字を区別しないファイルシステムでは問題ないが、GNU/Linuxのように大文字と小文字を区別しないファイルシステムがデフォルトの環境では`Dockerfile`が存在しないと認識されてしまう。

これは非常に重大な問題であるが、全く気付いていなかった。恥ずべきことである。反省したい。