### PR TITLE
Move browserslist to `package.json` Close #239

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,13 @@
       ]
     ]
   },
+  "browserslist": [
+    "Chrome >= 56",
+    "Edge >= 14",
+    "Firefox >= 51",
+    "iOS >= 10",
+    "Safari >= 10"
+  ],
   "bugs": {
     "url": "https://github.com/baberutv/baberutv/issues"
   },

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -30,13 +30,7 @@ const babelrc = {
         ],
         modules: false,
         targets: {
-          browsers: [
-            'Chrome >= 56',
-            'Edge >= 14',
-            'Firefox >= 51',
-            'iOS >= 10',
-            'Safari >= 10',
-          ],
+          browsers: pkg.browserslist,
         },
         useBuiltIns: true,
       },


### PR DESCRIPTION
対応する`babel-preset-env`のために記載する対象とするウェブブラウザーの一覧は`webpack.config.babel.js`に`babel-preset-env`の読み込みとともにしている。これにより変数`babelrc`のインデントが深くなってしまっていて可読性が悪い。`package.json`に記述を移して、その値を呼び出す形にする。

`babel-preset-env`は現時点では対応していないが`package.json`に対象とするウェブブラウザーの一覧が書かれていると`babel-preset-env`が依存している`browserslist`は`package.json`の値を評価する。`babel-preset-env`と同様に`browserslist`を使用している他のパッケージで共通した値が使えるようになるのではないかと期待したい。

### 関連Issue

- #239