### PR TITLE
Using dynamic import Close #240

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "babel": {
     "babelrc": false,
     "plugins": [
+      "syntax-dynamic-import",
       "transform-decorators-legacy",
       "transform-class-properties",
       "transform-react-jsx"
@@ -30,6 +31,7 @@
     "url": "https://github.com/baberutv/baberutv/issues"
   },
   "dependencies": {
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-polyfill": "^6.20.0",
     "context-provider": "^1.0.2",
     "dexie": "^v2.0.0-beta.4",
@@ -67,6 +69,7 @@
     "html-webpack-plugin": "^2.24.0",
     "jest": "^19.0.2",
     "npm-run-all": "^4.0.2",
+    "preload-webpack-plugin": "^1.2.0",
     "react-addons-test-utils": "^15.3.2",
     "webpack": "^2.2.0",
     "webpack-dev-server": "^2.2.0",
@@ -88,7 +91,8 @@
   "homepage": "https://baberu.tv/",
   "jest": {
     "collectCoverageFrom": [
-      "src/**/*.{js,jsx}"
+      "src/**/*.{js,jsx}",
+      "!src/client.jsx"
     ],
     "coverageDirectory": "<rootDir>/coverage",
     "moduleFileExtensions": [

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,0 +1,13 @@
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import React from 'react';
+import Main from './components/main';
+
+export default function App(props) {
+  return (
+    <MuiThemeProvider>
+      <Main {...props} />
+    </MuiThemeProvider>
+  );
+}
+
+App.displayName = 'App';

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -1,7 +1,6 @@
 import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './components/app';
 
 function insertCss(...styles) {
   // eslint-disable-next-line no-underscore-dangle
@@ -11,4 +10,24 @@ function insertCss(...styles) {
   };
 }
 
-ReactDOM.render(<App context={{ insertCss }} />, document.getElementById('root'));
+function render(component, container) {
+  return new Promise((resolve, reject) => {
+    try {
+      ReactDOM.render(component, container, resolve);
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function main() {
+  const container = document.getElementById('root');
+  const { default: App } = await import('./app');
+  try {
+    await render(<App context={{ insertCss }} />, container);
+  } catch (error) {
+    console.error(error); // eslint-disable-line no-console
+  }
+}
+
+main();

--- a/src/components/main.jsx
+++ b/src/components/main.jsx
@@ -1,6 +1,5 @@
 import provideContext from 'context-provider/lib/provideContext';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import React, { Component, PropTypes } from 'react';
 import URLSearchParams from 'url-search-params';
 import styles from '../styles/app.css';
@@ -18,7 +17,7 @@ function getQueryString() {
   insertCss: PropTypes.func.isRequired,
 })
 @withStyles(styles)
-export default class App extends Component {
+export default class Main extends Component {
   static contextTypes = {
     insertCss: PropTypes.func.isRequired,
   };
@@ -27,7 +26,7 @@ export default class App extends Component {
     setVideo: PropTypes.func.isRequired,
   };
 
-  static displayName = 'App';
+  static displayName = 'Main';
 
   state = {
     open: false,
@@ -97,14 +96,12 @@ export default class App extends Component {
 
   render() {
     return (
-      <MuiThemeProvider>
-        <div className="app">
-          <Header videoUri={this.state.videoUri} />
-          <main>
-            <Player src={this.state.videoUri} />
-          </main>
-        </div>
-      </MuiThemeProvider>
+      <div>
+        <Header videoUri={this.state.videoUri} />
+        <main>
+          <Player src={this.state.videoUri} />
+        </main>
+      </div>
     );
   }
 }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -2,6 +2,7 @@ import BabiliPlugin from 'babili-webpack-plugin';
 import CopyPlugin from 'copy-webpack-plugin';
 import HtmlPluign from 'html-webpack-plugin';
 import path from 'path';
+import PreloadPlugin from 'preload-webpack-plugin';
 import EnvironmentPlugin from 'webpack/lib/EnvironmentPlugin';
 import OccurrenceOrderPlugin from 'webpack/lib/optimize/OccurrenceOrderPlugin';
 import merge from 'webpack-merge';
@@ -16,6 +17,7 @@ const babelrc = {
     },
   },
   plugins: [
+    'syntax-dynamic-import',
     'transform-decorators-legacy',
     'transform-class-properties',
     'transform-react-jsx',
@@ -71,6 +73,8 @@ const clientConfig = {
     ],
   },
   output: {
+    chunkFilename: 'chunk.[id].js?[chunkhash]',
+    crossOriginLoading: 'anonymous',
     filename: '[name].js?[chunkhash]',
     path: path.join(__dirname, 'build', 'public'),
     publicPath: '/',
@@ -88,6 +92,7 @@ const clientConfig = {
       template: path.join(__dirname, 'src', 'templates', 'index.hbs'),
       title: process.env.BABERU_TV_SITE_NAME || `${pkg.name} (v${pkg.version})`,
     }),
+    new PreloadPlugin(),
     new EnvironmentPlugin([
       'NODE_ENV',
     ]),
@@ -116,6 +121,7 @@ export default (env = process.env.NODE_ENV) => {
     case 'production':
       return merge(clientConfig, {
         output: {
+          chunkFilename: 'chunk.[id].[chunkhash].js',
           filename: '[name].[chunkhash].js',
         },
         plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,8 +18,8 @@ accepts@~1.3.3:
     negotiator "0.6.1"
 
 acorn-dynamic-import@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.1.tgz#23f671eb6e650dab277fef477c321b1178a8cca2"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
   dependencies:
     acorn "^4.0.3"
 
@@ -566,6 +566,10 @@ babel-plugin-syntax-class-properties@^6.8.0:
 babel-plugin-syntax-decorators@^6.1.18:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
 
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
@@ -4586,6 +4590,12 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     js-base64 "^2.1.9"
     source-map "^0.5.6"
     supports-color "^3.2.3"
+
+preload-webpack-plugin@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/preload-webpack-plugin/-/preload-webpack-plugin-1.2.0.tgz#d8581794133aaa275307c1c975050bc550b13059"
+  dependencies:
+    object-assign "^4.1.1"
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
dynamic importを使い、アセットが分割されるようにする。

今後 #207 で`react-router`が導入されて各ページ用のReactコンポーネントをひとつのにバンドルしようとするとどうしてもスクリプトファイルのファイルサイズが肥大化していく。dynamic importを使うことによって必要になるまで読み込まれなくなるのでスクリプトファイル単体のファイルサイズは削減できる。

### 関連Issue

- #240