### PR TITLE
Add `--rm` argument to `docker-compose run` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ $ docker-compose up
 コードのフォーマットの確認には[ESLint](http://eslint.org/)を使っています。
 
 ```shell
-$ docker-compose run webpack yarn lint
+$ docker-compose run --rm webpack yarn lint
 ```
 
 というコマンドを実行することによって、コードフォーマットに正しく従えているかどうかを確認できます。
@@ -29,7 +29,7 @@ $ docker-compose run webpack yarn lint
 ## テスト
 
 ```shell
-$ docker-compose run webpack yarn test-only
+$ docker-compose run --rm webpack yarn test-only
 ```
 
 というコマンドを実行することによって自動テストが実行されます。テスト自体は[`./__tests__`](/__tests__)以下にありますが、現時点ではほとんど書かれていません。今後充実させていくというのが課題となっています。


### PR DESCRIPTION
`CONTRIBUTING.md`で`docker-compose run`コマンドを使っている箇所において`--rm`引数を追加させる。

`docker-compose run`コマンドに`--rm`引数を与えるとコマンドの実行終了後にコンテナの破棄がされるようになる。使用済みの不要なコンテナが溜まってしまうことを避けたいため、`--rm`引数の追加を推奨したい。