### PR TITLE
Using Alpine Linux for Docker Close #242

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM node:6.10.0
+FROM node:6.10.0-alpine
 
 ENV PATH /root/.yarn/bin:${PATH}
 ENV YARN_VERSION 0.21.3
 
 RUN \
-  curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VERSION}
+  apk add --no-cache --update --virtual .build-deps bash curl gnupg tar && \
+  curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VERSION} && \
+  apk del .build-deps
 
 WORKDIR /app
 


### PR DESCRIPTION
Dockerのイメージのファイルサイズを削減するためにAlpine Linuxをベースとするイメージを使うようにする。

CircleCIにおいてはデプロイなどのいくつかの処理をしなければならない都合上、Alpine LinuxではなくDebian GNU/Linuxをベースとするイメージのままである。ただし通常のものではなく`slim`版なので多少はファイルサイズの削減ができている。

### 関連Issue

- #242