### PR TITLE
Fix `docker build` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ BaberuTVはTVです。TVとはつまりTelevisionの略です。つまり遠隔�
 Dockerがインストールされている環境であれば、どのような環境でも動作します。
 
 ```shell
-$ docker build -t baberutv
+$ docker build -t baberutv .
 $ docker run -d -p 8080:8080 baberutv
 $ open http://localhost:8080/
 ```


### PR DESCRIPTION
`docker build`コマンドに与えている引数が欠けていたので修正する。