### PR TITLE
Add `docker pull` command from Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ BaberuTVはTVです。TVとはつまりTelevisionの略です。つまり遠隔�
 Dockerがインストールされている環境であれば、どのような環境でも動作します。
 
 ```shell
-$ docker build -t baberutv .
-$ docker run -d -p 8080:8080 baberutv
+$ docker pull baberutv/baberutv:latest
+$ docker run -d -p 8080:8080 baberutv:baberutv:latest
 $ open http://localhost:8080/
 ```
 


### PR DESCRIPTION
READMEに書いているDockerを使った起動のさせかたを、DockerのイメージをDocker Hubから`pull`してから実行させる形に変更させる。

`git`から`clone`する手順も書かずにDockerのイメージをビルドをさせる形になっており、あまりにも不親切である。