### PR TITLE
Remove dependencies for development from Docker image Close #253

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,11 @@ COPY ./package.json ./yarn.lock /app/
 RUN yarn
 
 COPY . /app/
-RUN yarn build -- --env production
+RUN \
+  yarn build -- --env production && \
+  rm -rf ./node_modules && \
+  yarn --production && \
+  rm -rf $(yarn cache dir)
 
 EXPOSE 8080
 CMD ["yarn", "start"]


### PR DESCRIPTION
Dockerのイメージをビルドする際にwebpackがビルドに使うファイルを削除させる。

webpackでビルドする際にはBabelが必要となるがBabelは関連するパッケージが非常に多いため、どうしても`./node_modules`ディレクトリー以下のファイルの数が多くなってしまう。それにともなって最終的な成果物であるDockerのイメージのファイルサイズも大きくなる。Dockerのイメージのファイルサイズが大きくなるとレジストリからイメージを取得する時間も大きくなってしまう。Dockerを使ったデプロイをするときに困ってしまうおそれがあるので、webpackのビルドでしか使われないものはイメージの中から削除させたい。