### PR TITLE
Split run steps for test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,11 @@ jobs:
             - ~/.cache/yarn
             - ./node_modules
       - run:
+          name: Pre-Test
+          command: yarn lint
+      - run:
           name: Run Tests
-          command: yarn test
+          command: yarn test-only
       - run:
           name: Post-Test
           command: cat ./coverage/lcov.info | $(yarn bin)/coveralls || echo "1"


### PR DESCRIPTION
CircleCIでコードリントとテスト実行処理のステップを分割させる。

これによりCircleCIのUIでの確認がしやすくなることを期待する。