### PR TITLE
Page splitting Close #207

### DIFF
--- a/__tests__/components/player.jsx
+++ b/__tests__/components/player.jsx
@@ -3,24 +3,15 @@ import React from 'react';
 import Player from '../../src/components/player';
 
 const context = {
-  styleManager: {
-    render: () => ({
-      player: 'player',
-    }),
-  },
+  setVideo() {},
 };
 
 test('mount', () => {
-  const player = shallow(<Player />, { context });
-  expect(player.find('.player').length).toBe(1);
+  const player = shallow(<Player location={{ search: '' }} />, { context });
+  expect(player.find('div').length).toBe(1);
 });
 
-test('aria-hidden=true', () => {
-  const player = shallow(<Player />, { context });
-  expect(player.find('.player[aria-hidden]').length).toBe(1);
-});
-
-test('aria-hidden=false', () => {
-  const player = shallow(<Player src="https://example.com/index.m3u8" />, { context });
-  expect(player.find('.player[aria-hidden=false]').length).toBe(1);
+test('have search', () => {
+  const player = shallow(<Player location={{ search: 'https://example.com/index.m3u8' }} />, { context });
+  expect(player.find('div').length).toBe(1);
 });

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "babelrc": false,
     "plugins": [
       "transform-class-properties",
+      "transform-object-rest-spread",
       "transform-react-jsx"
     ],
     "presets": [
@@ -38,6 +39,7 @@
     "material-ui": "^1.0.0-alpha.6",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
+    "react-router-dom": "^4.0.0-beta.7",
     "url-search-params": "^0.6.1"
   },
   "description": ":tv: Television!",
@@ -48,6 +50,7 @@
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.18.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-plugin-transform-react-jsx-source": "^6.9.0",
     "babel-preset-env": "^1.1.4",
@@ -89,6 +92,7 @@
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",
+      "!src/components/loader.jsx",
       "!src/client.jsx"
     ],
     "coverageDirectory": "<rootDir>/coverage",

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -1,6 +1,7 @@
 import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 function insertCss(...styles) {
   // eslint-disable-next-line no-underscore-dangle
@@ -24,7 +25,11 @@ async function main() {
   const container = document.getElementById('root');
   const { default: App } = await import('./app');
   try {
-    await render(<App context={{ insertCss }} />, container);
+    await render((
+      <Router>
+        <App context={{ insertCss }} />
+      </Router>
+    ), container);
   } catch (error) {
     console.error(error); // eslint-disable-line no-console
   }

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -9,15 +9,23 @@ import ToolBar from 'material-ui/Toolbar';
 import MenuIcon from 'material-ui/svg-icons/menu';
 import customPropTypes from 'material-ui/utils/customPropTypes';
 import React, { Component, PropTypes } from 'react';
+import { Link } from 'react-router-dom';
 
 const styleSheet = createStyleSheet('Header', () => ({
   title: {
     flex: 1,
   },
+  titleLink: {
+    color: 'inherit',
+    textDecoration: 'none',
+  },
 }));
 
 export default class Header extends Component {
   static contextTypes = {
+    history: PropTypes.shape({
+      push: PropTypes.func.isRequired,
+    }).isRequired,
     setVideo: PropTypes.func.isRequired,
     styleManager: customPropTypes.muiRequired,
   };
@@ -58,7 +66,11 @@ export default class Header extends Component {
 
   componentWillUpdate(nextProps) {
     if (nextProps.videoUri && this.props.videoUri !== nextProps.videoUri) {
-      this.setState({ open: false });
+      const newState = { open: false };
+      if (this.state.videoUri !== nextProps.videoUri) {
+        newState.videoUri = nextProps.videoUri;
+      }
+      this.setState(newState);
     }
   }
 
@@ -85,10 +97,14 @@ export default class Header extends Component {
   }
 
   handleSubmit = (event) => {
+    const { videoUri } = this.state;
     event.preventDefault();
-    this.context.setVideo({
-      uri: this.state.videoUri,
-    });
+    if (videoUri) {
+      this.setState({ open: false }, () => {
+        this.context.setVideo({ uri: videoUri })
+          .then(() => this.context.history.push(`/player/?uri=${videoUri}`));
+      });
+    }
     return false;
   }
 
@@ -101,7 +117,9 @@ export default class Header extends Component {
             <IconButton contrast>
               <MenuIcon onClick={this.handleClick} />
             </IconButton>
-            <Text className={classes.title} colorInherit type="title">TV</Text>
+            <Text className={classes.title} colorInherit type="title">
+              <Link className={classes.titleLink} to="/">TV</Link>
+            </Text>
             <Button contrast onClick={this.handleClick} primary>Open</Button>
             <Dialog onRequestClose={this.handleRequestClose} open={this.state.open}>
               <form action="/" onSubmit={this.handleSubmit}>

--- a/src/components/home.jsx
+++ b/src/components/home.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Home() {
+  return (
+    <div>
+      {/* home */ }
+    </div>
+  );
+}

--- a/src/components/loader.jsx
+++ b/src/components/loader.jsx
@@ -1,0 +1,33 @@
+import React, { Component, PropTypes } from 'react';
+
+export default class Loader extends Component {
+  static displayName = 'Loader';
+
+  static propTypes = {
+    name: PropTypes.string.isRequired,
+  };
+
+  state = {
+    component: null,
+  };
+
+  componentDidMount() {
+    const { name, ...otherProps } = this.props;
+    import(`./${name}`)
+      .then(({ default: C }) => {
+        this.setState({
+          component: (
+            <C {...otherProps} />
+          ),
+        });
+      });
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return this.state.component !== nextState.component;
+  }
+
+  render() {
+    return this.state.component;
+  }
+}

--- a/src/components/main.jsx
+++ b/src/components/main.jsx
@@ -1,14 +1,7 @@
 import React, { Component, PropTypes } from 'react';
-import URLSearchParams from 'url-search-params';
+import { Route } from 'react-router-dom';
+import Loader from './loader';
 import Header from './header';
-import Player from './player';
-
-function getQueryString() {
-  if (typeof location === 'undefined') {
-    return '';
-  }
-  return (location.search || '?').slice(1);
-}
 
 export default class Main extends Component {
   static childContextTypes = {
@@ -28,67 +21,17 @@ export default class Main extends Component {
     };
   }
 
-  componentWillMount() {
-    const queryString = getQueryString();
-    const searchParams = new URLSearchParams(queryString);
-    const videoUri = searchParams.get('uri');
-    if (videoUri) {
-      this.setState({ videoUri });
-    } else {
-      this.setState({
-        open: true,
-      });
-    }
-  }
-
-  componentDidMount() {
-    window.addEventListener('popstate', this.handlePopState);
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return (
-      this.state.open !== nextState.open ||
-      this.state.videoUri !== nextState.videoUri
-    );
-  }
-
-  componentWillUpdate(nextProps, nextState) {
-    const { open, videoUri } = nextState;
-    if (this.state.videoUri !== videoUri) {
-      if (videoUri && open) {
-        this.setState({
-          open: false,
-        });
-      }
-      const currentUri = location.pathname + location.search;
-      const uri = `/${videoUri ? `?uri=${encodeURIComponent(videoUri)}` : ''}`;
-      if (currentUri !== uri) {
-        history.pushState({ videoUri }, document.title, uri);
-      }
-    }
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('popstate', this.handlePopState);
-  }
-
-  setVideo = ({ uri }) => {
-    this.setState({
-      videoUri: uri,
-    });
-  }
-
-  handlePopState = ({ state }) => {
-    const { videoUri = '' } = state || {};
-    this.setState({ videoUri });
-  }
+  setVideo = async ({ uri }) => new Promise((resolve) => {
+    this.setState({ videoUri: uri }, resolve);
+  })
 
   render() {
     return (
       <div>
-        <Header videoUri={this.state.videoUri} />
+        <Header open={this.state.open} videoUri={this.state.videoUri} />
         <main>
-          <Player src={this.state.videoUri} />
+          <Route exact path="/" render={props => <Loader name="home" {...props} />} />
+          <Route path="/player/" render={props => <Loader name="player" {...props} />} />
         </main>
       </div>
     );

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -19,6 +19,7 @@ const babelrc = {
   plugins: [
     'syntax-dynamic-import',
     'transform-class-properties',
+    'transform-object-rest-spread',
     'transform-react-jsx',
   ],
   presets: [
@@ -37,6 +38,18 @@ const babelrc = {
       },
     ],
   ],
+};
+
+const htmlTemplateOptions = {
+  minify: {
+    collapseBooleanAttributes: true,
+    collapseWhitespace: true,
+    removeAttributeQuotes: true,
+    removeOptionalTags: true,
+    removeScriptTypeAttributes: true,
+    removeStyleLinkTypeAttributes: true,
+  },
+  template: path.join(__dirname, 'src', 'templates', 'index.hbs'),
 };
 
 const clientConfig = {
@@ -73,16 +86,13 @@ const clientConfig = {
   },
   plugins: [
     new HtmlPluign({
-      minify: {
-        collapseBooleanAttributes: true,
-        collapseWhitespace: true,
-        removeAttributeQuotes: true,
-        removeOptionalTags: true,
-        removeScriptTypeAttributes: true,
-        removeStyleLinkTypeAttributes: true,
-      },
-      template: path.join(__dirname, 'src', 'templates', 'index.hbs'),
+      ...htmlTemplateOptions,
       title: process.env.BABERU_TV_SITE_NAME || `${pkg.name} (v${pkg.version})`,
+    }),
+    new HtmlPluign({
+      ...htmlTemplateOptions,
+      filename: 'player/index.html',
+      title: `player - ${process.env.BABERU_TV_SITE_NAME || `${pkg.name} (v${pkg.version})`}`,
     }),
     new EnvironmentPlugin([
       'NODE_ENV',

--- a/yarn.lock
+++ b/yarn.lock
@@ -585,6 +585,10 @@ babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-syntax-trailing-function-commas@^6.13.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
@@ -799,6 +803,13 @@ babel-plugin-transform-minify-booleans@^6.8.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.8.0.tgz#b1a48864a727847696b84eae36fa4d085a54b42b"
   dependencies:
     babel-runtime "^6.0.0"
+
+babel-plugin-transform-object-rest-spread@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz#875d6bc9be761c58a2ae3feee5dc4895d8c7f921"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.22.0"
 
 babel-plugin-transform-property-literals@^6.8.1:
   version "6.8.1"
@@ -2693,6 +2704,16 @@ he@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/he/-/he-0.5.0.tgz#2c05ffaef90b68e860f3fd2b54ef580989277ee2"
 
+history@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.5.1.tgz#44935a51021e3b8e67ebac267a35675732aba569"
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.0.0"
+    value-equal "^0.2.0"
+    warning "^3.0.0"
+
 hls.js@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-0.7.2.tgz#90b03d14ec901a3f45c801492d20c36934594b95"
@@ -2926,7 +2947,7 @@ interpret@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
-invariant@^2.2.0, invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -3788,7 +3809,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -4323,6 +4344,12 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+path-to-regexp@^1.5.3:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -4816,6 +4843,23 @@ react-event-listener@^0.4.2:
     react-addons-shallow-compare "^15.4.2"
     warning "^3.0.0"
 
+react-router-dom@^4.0.0-beta.7:
+  version "4.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.0.0-beta.7.tgz#3eeea51407efe91e4e28c49fcd486dfc0f9341dc"
+  dependencies:
+    history "^4.5.1"
+    react-router "^4.0.0-beta.7"
+
+react-router@^4.0.0-beta.7:
+  version "4.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.0.0-beta.7.tgz#e82931139ed26a99cd5251e2cf2a7b47daceb483"
+  dependencies:
+    history "^4.5.1"
+    invariant "^2.2.2"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.5.3"
+    warning "^3.0.0"
+
 react@^15.3.2:
   version "15.4.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
@@ -5050,6 +5094,10 @@ requires-port@1.0.x, requires-port@1.x.x:
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
+resolve-pathname@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.0.2.tgz#e55c016eb2e9df1de98e85002282bfb38c630436"
 
 resolve@1.1.7:
   version "1.1.7"
@@ -5712,6 +5760,10 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
+
+value-equal@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.2.0.tgz#4f41c60a3fc011139a2ec3d3340a8998ae8b69c0"
 
 vary@~1.1.0:
   version "1.1.0"


### PR DESCRIPTION
トップにいくつかの情報を載せたり、ほかのページを追加するための布石として、動画プレイヤーをトップに配置するのではなくほかのURIのべつのページとして切り出すようにする。

`react-router` v4.0.0を使い、かつdynamic importを使っているため、該当ページがロードされるまでページ本体のスクリプトファイルは読み込まれない。そのためページの数が増えてもスクリプトファイル自体のファイルサイズが大きくなりすぎることはないのではない。……と期待している。

### 関連Issue

- #207