### PR TITLE
Remove `babel-plugin-transform-es2015-modules-commonjs` dependency from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "babel-loader": "^6.2.7",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.18.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-plugin-transform-react-jsx-source": "^6.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -694,7 +694,7 @@ babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015
     babel-runtime "^6.22.0"
     babel-template "^6.22.0"
 
-babel-plugin-transform-es2015-modules-commonjs@^6.18.0, babel-plugin-transform-es2015-modules-commonjs@^6.22.0, babel-plugin-transform-es2015-modules-commonjs@^6.6.0:
+babel-plugin-transform-es2015-modules-commonjs@^6.22.0, babel-plugin-transform-es2015-modules-commonjs@^6.6.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.23.0.tgz#cba7aa6379fb7ec99250e6d46de2973aaffa7b92"
   dependencies:


### PR DESCRIPTION
`package.json`から`babel-plugin-transform-es2015-modules-commonjs`の依存を取り除く。

`babel-plugin-transform-es2015-modules-commonjs`は`babel-preset-env`が依存していて、他の箇所からは読み込まれていない。そのため`package.json`に依存の記述をする必要性はない。
また`babel-preset-env`が指定するバージョンとずれが生じてしまったときに複数バージョンのものがインストールされることになってしまう。ダウンロード時間の無駄でしかなく、またストレージを圧迫することとなり無駄でしかない。