### PR TITLE
Upgrade `preload-webpack-plugin` to v1.2.1 Close #252

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "html-webpack-plugin": "^2.24.0",
     "jest": "^19.0.2",
     "npm-run-all": "^4.0.2",
-    "preload-webpack-plugin": "^1.2.0",
+    "preload-webpack-plugin": "^1.2.1",
     "react-addons-test-utils": "^15.3.2",
     "webpack": "^2.2.0",
     "webpack-dev-server": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4230,9 +4230,9 @@ portfinder@^1.0.9:
     debug "^2.2.0"
     mkdirp "0.5.x"
 
-preload-webpack-plugin@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/preload-webpack-plugin/-/preload-webpack-plugin-1.2.0.tgz#d8581794133aaa275307c1c975050bc550b13059"
+preload-webpack-plugin@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/preload-webpack-plugin/-/preload-webpack-plugin-1.2.1.tgz#591c25fbbaee1a9fd95174b049f53272ed9622e9"
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
`preload-webpack-plugin` v1.2.0以前にはソースマップもpreloadしてしまう不具合がある。v1.2.1で修正されたためバージョンアップをして解決を図る。