### PR TITLE
Remove `crossorigin` attribute for production environment Close #279

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -124,11 +124,13 @@ export default (env = process.env.NODE_ENV) => {
       return merge(clientConfig, {
         output: {
           chunkFilename: 'chunk.[id].[chunkhash].js',
+          crossOriginLoading: false,
           filename: '[name].[chunkhash].js',
         },
         plugins: [
           new PreloadPlugin(),
           new SubResourceIntegrityPlugin({
+            enabled: false,
             hashFuncNames: ['sha512'],
           }),
           new OccurrenceOrderPlugin(),


### PR DESCRIPTION
dynamic importで切り出したスクリプトファイルを呼び出す際に、`script`要素に`crossorigin`属性を追加するのを止める。

`crossorigin`属性を持つ`script`要素を`preload`させる場合は`rel`属性の値を`preload`にした`link`要素にも`crossorigin`属性を追加させなければならない。`preload-webpack-plugin`はv1.2.1現在、`crossorigin`属性の追加には対応していない。そのため、`preload-webpack-plugin`を使っている限りは`crossorigin`属性を`script`要素に足せない。

また`crossorigin`属性と同様に`integrity`属性を持っている場合も同様である。ただし`link`要素は`rel`属性の値が`stylesheet`の時以外は`integrity`属性を持たせることはできない。仕様にない動作であるため、当然 ウェブブラウザーからも適切に認識されることはない。

`crossorigin`属性の値が`anonymous`でない場合は`integrity`属性を持たせられないため、`preload-webpack-plugin`が`crossorigin`属性の追加に対応していない時点で`integrity`属性の追加もできなくなっているのではあるが、非常に残念でならない。

これは敗北のコミットである。